### PR TITLE
Change deno-moo version to compatible one → v0.0.4

### DIFF
--- a/generated/urichk.js
+++ b/generated/urichk.js
@@ -2,7 +2,7 @@
     // nearley version: 2.20.1
     // export name: urichk
     
-  import { compileStates } from "https://deno.land/x/moo@0.5.1-deno.2/mod.ts";
+  import { states } from "https://deno.land/x/moo@0.5.1.1/index.ts";
   const commonTokenRules = {
     num: /[0-9]+/,
     ln: { match: /\r?\n/, lineBreaks: true },
@@ -11,7 +11,7 @@
     sc: /\/\/[^\r\n]*\r?\n/,
     mc: /\/\*(?:\*(?!\/)|[^*])*\*\//,
   };
-  const lexer = compileStates({
+  const lexer = states({
     root: {
       ...commonTokenRules,
       lcb: { match: '{', push: 'block' },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "urichk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "(MIT OR Apache-2.0)",
   "scripts": {
     "build:nearley": "node script/nearleyc.js",

--- a/script/build-npm.ts
+++ b/script/build-npm.ts
@@ -29,12 +29,6 @@ await build({
       url: "https://github.com/riiid/urichk/issues",
     },
   },
-  mappings: {
-    "https://deno.land/x/moo@0.5.1-deno.2/mod.ts": {
-      name: "moo",
-      version: "0.5.1",
-    },
-  },
   declaration: true,
   typeCheck: false,
   test: false,

--- a/urichk.ne
+++ b/urichk.ne
@@ -1,7 +1,7 @@
 @preprocessor urichk
 
 @{%
-  import { compileStates } from "https://deno.land/x/moo@0.5.1-deno.2/mod.ts";
+  import { states } from "https://deno.land/x/moo@0.5.1.1/index.ts";
   const commonTokenRules = {
     num: /[0-9]+/,
     ln: { match: /\r?\n/, lineBreaks: true },
@@ -10,7 +10,7 @@
     sc: /\/\/[^\r\n]*\r?\n/,
     mc: /\/\*(?:\*(?!\/)|[^*])*\*\//,
   };
-  const lexer = compileStates({
+  const lexer = states({
     root: {
       ...commonTokenRules,
       lcb: { match: '{', push: 'block' },


### PR DESCRIPTION
- moo@0.5.1-deno.2 has different export names, so I changed it to moo@0.5.1.1 which is compatible with REAL moo(on node)
- moo@0.5.1.1 also don't occur type error when emitDeclaration phase. so mapping is unnecessary.