### PR TITLE
Refactor to use encodeURI instead of encode to ensure browser compatibility

### DIFF
--- a/compile/get-path.ts
+++ b/compile/get-path.ts
@@ -17,8 +17,6 @@ export function compile(
   const { name = "" } = config ?? {};
   const defaultFunctionName = `get${kebabToPascal(name)}Path`;
   return `
-import {encode} from 'querystring';
-
 export interface PathParamsTable {${
     schema.map((rule) => {
       const path = JSON.stringify(urichkPathToString(rule.head.path || []));
@@ -35,7 +33,7 @@ export interface PathParamsTable {${
 export default function ${defaultFunctionName}<Path extends keyof PathParamsTable>(path: Path, searchParams?: PathParamsTable[Path]): string {
   const query = (
       searchParams ?
-      '?' + encode(searchParams) :
+      '?' + encodeURI(Object.entries(searchParams).map(([key, value]) => \`\${key}=\${value}\`).join('&')) :
       ''
     );
   return path + query;

--- a/compile/nextjs-navigation-hook.ts
+++ b/compile/nextjs-navigation-hook.ts
@@ -22,7 +22,7 @@ export function compile(
   return `
     import {useCallback} from 'react';
     import {useRouter} from 'next/router';
-    import {encode} from 'querystring';
+
     export interface NavigateConfig {
       replace: boolean; // true: replace, false: push
       shallow: boolean;
@@ -46,7 +46,7 @@ export function compile(
         const navigateFn = replace ? router.replace : router.push;
         const query = (
           searchParams ?
-          '?' + encode(searchParams) :
+          '?' + encodeURI(Object.entries(searchParams).map(([key, value]) => \`\${key}=\${value}\`).join('&')) :
           ''
         );
         navigateFn(path + query, undefined, { shallow });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "urichk",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "(MIT OR Apache-2.0)",
   "scripts": {
     "build:nearley": "node script/nearleyc.js",


### PR DESCRIPTION
> querystring is more performant than [\<URLSearchParams\>](https://nodejs.org/api/url.html#class-urlsearchparams) but is not a standardized API. Use [\<URLSearchParams\>](https://nodejs.org/api/url.html#class-urlsearchparams) when performance is not critical or when compatibility with browser code is desirable. - https://nodejs.org/api/querystring.html