### PR TITLE
Fix bug with nullish value

### DIFF
--- a/compile/get-path.ts
+++ b/compile/get-path.ts
@@ -33,7 +33,7 @@ export interface PathParamsTable {${
 export default function ${defaultFunctionName}<Path extends keyof PathParamsTable>(path: Path, searchParams?: PathParamsTable[Path]): string {
   const query = (
       searchParams ?
-      '?' + encodeURI(Object.entries(searchParams).map(([key, value]) => \`\${key}=\${value}\`).join('&')) :
+      '?' + encodeURI(Object.entries(searchParams).map(([key, value]) => \`\${key}=\${value ?? ''}\`).join('&')) :
       ''
     );
   return path + query;

--- a/compile/nextjs-navigation-hook.ts
+++ b/compile/nextjs-navigation-hook.ts
@@ -46,7 +46,7 @@ export function compile(
         const navigateFn = replace ? router.replace : router.push;
         const query = (
           searchParams ?
-          '?' + encodeURI(Object.entries(searchParams).map(([key, value]) => \`\${key}=\${value}\`).join('&')) :
+          '?' + encodeURI(Object.entries(searchParams).map(([key, value]) => \`\${key}=\${value ?? ''}\`).join('&')) :
           ''
         );
         navigateFn(path + query, undefined, { shallow });


### PR DESCRIPTION
- #17 이 기존 동작을 바꿔버려서🤧 수정합니다.
# 오류 동작
```
> const {encode} = require('querystring');
undefined
> encode({a:null, b:'a'})
'a=&b=a'
> encodeURI(Object.entries({a:null, b:'a'}).map(([key, value]) => `${key}=${value}`).join('&'))
'a=null&b=a' // 오류
> encode({a:undefined, b:'a'})
'a=&b=a'
> encodeURI(Object.entries({a:undefined, b:'a'}).map(([key, value]) => `${key}=${value}`).join('&'))
'a=undefined&b=a' // 오류
> encode({a:'', b:'a'})
'a=&b=a'
> encodeURI(Object.entries({a:'', b:'a'}).map(([key, value]) => `${key}=${value}`).join('&'))
'a=&b=a'
```
# 수정 버전
```
> const {encode} = require('querystring');
undefined
> encode({a:null, b:'a'})
'a=&b=a'
> encodeURI(Object.entries({a:null, b:'a'}).map(([key, value]) => `${key}=${value ?? ''}`).join('&'))
'a=&b=a'
> encode({a:undefined, b:'a'})
'a=&b=a'
> encodeURI(Object.entries({a:undefined, b:'a'}).map(([key, value]) => `${key}=${value ?? ''}`).join('&'))
'a=&b=a'
> encode({a:'', b:'a'})
'a=&b=a'
> encodeURI(Object.entries({a:'', b:'a'}).map(([key, value]) => `${key}=${value ?? ''}`).join('&'))
'a=&b=a'
> encode({a:0, b:'a'})
'a=0&b=a'
> encodeURI(Object.entries({a:0, b:'a'}).map(([key, value]) => `${key}=${value ?? ''}`).join('&'))
'a=0&b=a'
```